### PR TITLE
amd64/Dockerfile: Timezone and locale fixes

### DIFF
--- a/amd64/Dockerfile
+++ b/amd64/Dockerfile
@@ -32,4 +32,8 @@ ONBUILD RUN emerge-webrsync -q
 ONBUILD RUN eselect news read new
 # Finalization
 ONBUILD RUN emerge --config sys-libs/timezone-data
+ONBUILD RUN echo en_US ISO-8859-1 > /etc/locale.gen
+ONBUILD RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
+ONBUILD RUN locale-gen
+ONBUILD RUN echo 'LANG="en_US.UTF-8"' >> /etc/env.d/02locale
 ONBUILD RUN env-update


### PR DESCRIPTION
Grab lines from my gentoo-utc [1](https://github.com/wking/dockerfile/blob/d187ff88a909275afdaefdbabae7dc5a8a3e6165/gentoo-en-us/Dockerfile.template#L28) and gentoo-en-us [2](https://github.com/wking/dockerfile/blob/d187ff88a909275afdaefdbabae7dc5a8a3e6165/gentoo-utc/Dockerfile.template#L29) Dockerfiles
that seem appropriate here.

I'm not sold on the ONBUILD approach, because it seems like it would
be better to build these steps in additional layers (as I do [3](https://github.com/wking/dockerfile/blob/d187ff88a909275afdaefdbabae7dc5a8a3e6165/build.sh#L229)) and
push the resulting images (as I don't).  Then everybody using the
image doesn't have to re-install the Portage tree or rebuild their
locales locally (unless they want to).  I'm not sure how caching works
with ONBUILD either, hopefully they only have to run the ONBUILD
commands once for each local image they base on this one?
