### PR TITLE
amd64 image: run docker build as root

### DIFF
--- a/amd64/build.sh
+++ b/amd64/build.sh
@@ -23,4 +23,4 @@ fi
 echo "I'm done with the stage3."
 
 echo "Building docker Gentoo image now..."
-docker build -t gentoo .
+sudo docker build -t gentoo .


### PR DESCRIPTION
`docker build` command should run as root with `sudo` or `su - root -c "docker build -t gentoo ."` since the regular user doesn't have the permission to talk with docker's running socket.
e.g.
Running docker build as a regular user I get the following:
     `$ docker build -t gentoo .`
    `2014/07/08 03:58:56 Post http:///var/run/docker.sock/build?rm=1&t=gentoo: dial unix /var/run/docker.sock: permission denied`

:whale:
