### PR TITLE
add amd64 hardened support

### DIFF
--- a/amd64-hardened/Dockerfile
+++ b/amd64-hardened/Dockerfile
@@ -1,0 +1,38 @@
+FROM scratch
+
+MAINTAINER Gentoo Docker Team
+
+# This one should be present by running the build.sh script
+ADD stage3-amd64-hardened.tar.xz /
+
+# Setup the (virtually) current runlevel
+RUN echo "default" > /run/openrc/softlevel
+
+# Setup the rc_sys
+RUN sed -e 's/#rc_sys=""/rc_sys="lxc"/g' -i /etc/rc.conf
+
+# Setup the net.lo runlevel
+RUN ln -s /etc/init.d/net.lo /run/openrc/started/net.lo
+
+# Setup the net.eth0 runlevel
+RUN ln -s /etc/init.d/net.lo /etc/init.d/net.eth0
+RUN ln -s /etc/init.d/net.eth0 /run/openrc/started/net.eth0
+
+# By default, UTC system
+RUN echo 'UTC' > /etc/timezone
+
+# Used when this image is the base of another
+#
+# Setup the portage directory and permissions
+ONBUILD RUN mkdir -p /usr/portage/{distfiles,metadata,packages}
+ONBUILD RUN chown -R portage:portage /usr/portage
+ONBUILD RUN echo "masters = gentoo" > /usr/portage/metadata/layout.conf
+
+# Sync portage
+ONBUILD RUN emerge-webrsync -q
+
+# Display some news items
+ONBUILD RUN eselect news read new
+
+# Finalization
+ONBUILD RUN env-update

--- a/amd64-hardened/build.sh
+++ b/amd64-hardened/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+die(){ echo "$@" 1>&2; exit 1; }
+
+base_url="http://distfiles.gentoo.org/releases/amd64/autobuilds"
+
+latest_stage3=$(curl "${base_url}/latest-stage3-amd64-hardened.txt" 2>/dev/null | grep -v '#')
+stage3=$(basename "${latest_stage3}")
+
+[ ! -f "${stage3}" ] && xz=true || xz=false
+
+wget -nc "${base_url}/${latest_stage3}" || die "Could not download stage3"
+wget -nc "${base_url}/${latest_stage3}.DIGESTS.asc" || die "Could not download digests"
+wget -nc "${base_url}/${latest_stage3}.CONTENTS" || die "Could not download contents"
+sha512_digests=$(grep -A1 SHA512 "${stage3}.DIGESTS.asc" | grep -v '^--')
+gpg --verify "${stage3}.DIGESTS.asc" || die "Insecure digests"
+echo "${sha512_digests}" | sha512sum -c || die "Checksum validation failed"
+
+if [ ${xz} == true ] || [ ! -f stage3-amd64.tar.xz ]; then
+	echo "Transforming bz2 tarball to xz (golang bug). This will take some time..."
+	bunzip2 -c "${stage3}" | xz -z > stage3-amd64-hardened.tar.xz || die "Failed to recompress to xz"
+fi
+echo "I'm done with the stage3."
+
+echo "Building docker Gentoo image now..."
+docker build -t gentoo:latest-hardened .


### PR DESCRIPTION
Build script for creating docker image based on the  amd64 hardened stage3 tarball. The image is created under the `latest-hardened` tag.
