### PR TITLE
add portage Dockerfile

### DIFF
--- a/portage/Dockerfile
+++ b/portage/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox:latest
+MAINTAINER Gentoo Container Team <containers@gentoo.org>
+
+ADD http://distfiles.gentoo.org/snapshots/portage-latest.tar.bz2 /
+RUN mkdir /usr && bzcat /portage-latest.tar.bz2 | tar -xf - -C /usr


### PR DESCRIPTION
This Dockerfile should build automatically even on hub.  I'll add this
and setup a cronjob to poke the hub's API daily so we should get daily
portage Docker images.

Let me know if there is anything I'm not considering here.  I'll add the cronjob script to a scripts directory in this repository.  Let me know if you think that commit should be a part of this pull request or not.

Again, if I don't hear anything by January 1, I'll go ahead and merge this; otherwise, I'll incorporate feedback accordingly.