### PR TITLE
Fixed parsing of latest tarball

### DIFF
--- a/amd64-hardened/build.sh
+++ b/amd64-hardened/build.sh
@@ -4,7 +4,7 @@ die(){ echo "$@" 1>&2; exit 1; }
 
 base_url="http://distfiles.gentoo.org/releases/amd64/autobuilds"
 
-latest_stage3=$(curl "${base_url}/latest-stage3-amd64-hardened.txt" 2>/dev/null | grep -v '#')
+latest_stage3=$(curl "${base_url}/latest-stage3-amd64-hardened.txt" 2>/dev/null | grep -v '#' | awk '{print $1}')
 stage3=$(basename "${latest_stage3}")
 
 [ ! -f "${stage3}" ] && xz=true || xz=false

--- a/amd64/build.sh
+++ b/amd64/build.sh
@@ -4,7 +4,7 @@ die(){ echo "$@" 1>&2; exit 1; }
 
 base_url="http://distfiles.gentoo.org/releases/amd64/autobuilds"
 
-latest_stage3=$(curl "${base_url}/latest-stage3-amd64.txt" 2>/dev/null | grep -v '#')
+latest_stage3=$(curl "${base_url}/latest-stage3-amd64.txt" 2>/dev/null | grep -v '#' | awk '{print $1}')
 stage3=$(basename "${latest_stage3}")
 
 [ ! -f "${stage3}" ] && xz=true || xz=false


### PR DESCRIPTION
The latest-stage3-ARCH.txt files seems to contains a number at the end of the line now.
i.e: http://distfiles.gentoo.org/releases/amd64/autobuilds/latest-stage3-amd64.txt

I added a `awk` to ensure `latest_stage3` to be a valid url