### PR TITLE
add /usr/portage volume to portage image

### DIFF
--- a/portage/Dockerfile
+++ b/portage/Dockerfile
@@ -6,3 +6,5 @@ ADD http://distfiles.gentoo.org/snapshots/portage-latest.tar.bz2 /
 RUN mkdir -p /usr
 RUN bzcat /portage-latest.tar.bz2 | tar -xf - -C /usr
 RUN mkdir -p /usr/portage/distfiles /usr/portage/metadata /usr/portage/packages
+
+VOLUME /usr/portage


### PR DESCRIPTION
We need to export the /usr/portage directory as a volume to use this
image as a data volume and successfully use it as a remote portage
directory.