### PR TITLE
Use busybox as baseimage

### DIFF
--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -25,8 +25,9 @@ RUN apk add --no-cache gnupg tar wget xz \
  && tar xJpf ${SNAPSHOT} -C usr \
  && rm ${SNAPSHOT} ${SNAPSHOT}.gpgsig ${SNAPSHOT}.md5sum
 
-FROM scratch
+FROM busybox:latest
 
 WORKDIR /
-
 COPY --from=builder /portage/ /
+CMD /bin/true
+VOLUME /usr/portage


### PR DESCRIPTION
* Provide /bin/true to create the data container
* Export VOLUME again


Addressing https://github.com/gentoo/gentoo-docker-images/issues/42