### PR TITLE
Stage3 name fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ https://hub.docker.com/u/gentoo/
 The containers are created using a multi-stage build, which requires docker-17.05.0 or later.
 The container being built is defined by the TARGET environment variable:
 
-`` TARGET=stage-amd64 ./build.sh ``
+`` TARGET=stage3-amd64 ./build.sh ``
 
 # Using the portage container as a data volume
 
 ```
 docker create -v /usr/portage --name myportagesnapshot gentoo/portage:latest /bin/true
-docker run --volumes-from myportagesnapshot gentoo/stage-amd64:latest /bin/bash
+docker run --volumes-from myportagesnapshot gentoo/stage3-amd64:latest /bin/bash
 ```
 
 # Contributing

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,10 @@
 # TARGET env variable.
 # Example usage: TARGET=stage3-amd64 ./build.sh
 
+if [[ -z "$TARGET" ]]; then
+	echo "TARGET environment variable must be set e.g. TARGET=stage3-amd64."
+	exit 1
+fi
 
 # Split the TARGET variable into three elements separated by hyphens
 IFS=- read -r NAME ARCH SUFFIX <<< "${TARGET}"

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # Used to create Gentoo stage3 and portage containers simply by specifying a 
 # TARGET env variable.
-# Example usage: TARGET=stage-amd64 ./build.sh
+# Example usage: TARGET=stage3-amd64 ./build.sh
 
 
 # Split the TARGET variable into three elements separated by hyphens


### PR DESCRIPTION
A couple of commands in the readme file don't seem to work - they refer to `TARGET` "stage" rather than "stage3" - there may have been a rename in the past.

Also added a fail-fast in build with an error message if `TARGET` is not set.