### PR TITLE
Various Docker/Travis build fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ ORG=${ORG:-gentoo}
 # x86 requires the i686 subfolder
 if [[ "${ARCH}" == "x86" ]]; then
 	MICROARCH="i686"
-	BOOTSTRAP="multiarch/alpine:x86-v3.6"
+	BOOTSTRAP="multiarch/alpine:x86-v3.7"
 else
 	MICROARCH="${ARCH}"
 fi

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.7 as builder
 WORKDIR /portage
 
 ARG SNAPSHOT="portage-latest.tar.xz"
-ARG DIST="http://distfiles.gentoo.org/snapshots"
+ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/snapshots"
 ARG SIGNING_KEY="0xEC590EEAC9189250"
 
 RUN apk add --no-cache gnupg tar wget xz \

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache gnupg tar wget xz \
  && gpg --list-keys \
  && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
+ && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${SNAPSHOT}.gpgsig" "${SNAPSHOT}" \
  && md5sum -c ${SNAPSHOT}.md5sum \

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -6,7 +6,7 @@
 # As gpg keyservers sometimes are unreliable, we use multiple gpg server pools
 # to fetch the signing key.
 
-FROM alpine:3.6 as builder
+FROM alpine:3.7 as builder
 
 WORKDIR /portage
 

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -19,10 +19,8 @@ RUN apk add --no-cache gnupg tar wget xz \
  && gpg --list-keys \
  && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
- && gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${SNAPSHOT}.gpgsig" "${SNAPSHOT}" \
- || gpg --keyserver keys.gnupg.net --recv-keys ${SIGNING_KEY} \
- || gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys ${SIGNING_KEY} \
  && md5sum -c ${SNAPSHOT}.md5sum \
  && mkdir -p usr/portage/distfiles usr/portage/packages \
  && tar xJpf ${SNAPSHOT} -C usr \

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -15,7 +15,7 @@ ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/snapshots"
 ARG SIGNING_KEY="0xEC590EEAC9189250"
 
 RUN apk add --no-cache gnupg tar wget xz \
- && wget -q -c "${DIST}/${SNAPSHOT}" "${DIST}/${SNAPSHOT}.gpgsig" "${DIST}/${SNAPSHOT}.md5sum" \
+ && wget -q "${DIST}/${SNAPSHOT}" "${DIST}/${SNAPSHOT}.gpgsig" "${DIST}/${SNAPSHOT}.md5sum" \
  && gpg --list-keys \
  && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -16,6 +16,9 @@ ARG SIGNING_KEY="0xEC590EEAC9189250"
 
 RUN apk add --no-cache gnupg tar wget xz \
  && wget -q -c "${DIST}/${SNAPSHOT}" "${DIST}/${SNAPSHOT}.gpgsig" "${DIST}/${SNAPSHOT}.md5sum" \
+ && gpg --list-keys \
+ && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
+ && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
  && gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${SNAPSHOT}.gpgsig" "${SNAPSHOT}" \
  || gpg --keyserver keys.gnupg.net --recv-keys ${SIGNING_KEY} \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /gentoo
 ARG ARCH=amd64
 ARG MICROARCH=amd64
 ARG SUFFIX
-ARG DIST="http://distfiles.gentoo.org/releases/${ARCH}/autobuilds/"
+ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/releases/${ARCH}/autobuilds/"
 ARG SIGNING_KEY="0xBB572E0E2D182910"
 
 RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${DIST}" \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -22,6 +22,9 @@ RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${
  && STAGE3PATH="$(wget -q -O- "${DIST}/latest-stage3-${MICROARCH}${SUFFIX}.txt" | tail -n 1 | cut -f 1 -d ' ')" \
  && STAGE3="$(basename ${STAGE3PATH})" \
  && wget -q -c "${DIST}/${STAGE3PATH}" "${DIST}/${STAGE3PATH}.CONTENTS" "${DIST}/${STAGE3PATH}.DIGESTS.asc" \
+ && gpg --list-keys \
+ && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
+ && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
  && gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  || gpg --keyserver keys.gnupg.net --recv-keys ${SIGNING_KEY} \
  || gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys ${SIGNING_KEY} \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -25,9 +25,7 @@ RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${
  && gpg --list-keys \
  && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
- && gpg --keyserver hkps.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
- || gpg --keyserver keys.gnupg.net --recv-keys ${SIGNING_KEY} \
- || gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys ${SIGNING_KEY} \
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${STAGE3}.DIGESTS.asc" \
  && awk '/# SHA512 HASH/{getline; print}' ${STAGE3}.DIGESTS.asc | sha512sum -c \
  && tar xjpf "${STAGE3}" --xattrs --numeric-owner \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -14,14 +14,15 @@ WORKDIR /gentoo
 ARG ARCH=amd64
 ARG MICROARCH=amd64
 ARG SUFFIX
-ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/releases/${ARCH}/autobuilds/"
+ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/releases/${ARCH}/autobuilds"
 ARG SIGNING_KEY="0xBB572E0E2D182910"
 
 RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${DIST}" \
  && apk --no-cache add gnupg tar wget \
- && STAGE3PATH="$(wget -q -O- "${DIST}/latest-stage3-${MICROARCH}${SUFFIX}.txt" | tail -n 1 | cut -f 1 -d ' ')" \
+ && STAGE3PATH="$(wget -O- "${DIST}/latest-stage3-${MICROARCH}${SUFFIX}.txt" | tail -n 1 | cut -f 1 -d ' ')" \
+ && echo "STAGE3PATH:" $STAGE3PATH \
  && STAGE3="$(basename ${STAGE3PATH})" \
- && wget -q -c "${DIST}/${STAGE3PATH}" "${DIST}/${STAGE3PATH}.CONTENTS" "${DIST}/${STAGE3PATH}.DIGESTS.asc" \
+ && wget -q "${DIST}/${STAGE3PATH}" "${DIST}/${STAGE3PATH}.CONTENTS" "${DIST}/${STAGE3PATH}.DIGESTS.asc" \
  && gpg --list-keys \
  && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -7,7 +7,7 @@
 # to fetch the signing key.
 
 ARG BOOTSTRAP
-FROM ${BOOTSTRAP:-alpine:3.6} as builder
+FROM ${BOOTSTRAP:-alpine:3.7} as builder
 
 WORKDIR /gentoo
 

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -25,6 +25,7 @@ RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${
  && gpg --list-keys \
  && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
+ && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${STAGE3}.DIGESTS.asc" \
  && awk '/# SHA512 HASH/{getline; print}' ${STAGE3}.DIGESTS.asc | sha512sum -c \


### PR DESCRIPTION
It looks like `gpg` networking became fragile, either on Travis or as part of DNS/service changes on the main keyservers.  There are some known bugs/fixes e.g. https://dev.gnupg.org/T2889 gnupg/dirmngr 2.1.17 fails on all keyserver operations.  Unclear if that applies here but there are certainly intermittent issues with `gpg`.

This PR applies one of the workarounds for the above bug by forcing the `gpg` environment with `dirmngr` config for `standard-resolver`.  Also snuck-in `honor-http-proxy` to help local builds behind a proxy server.  Then added `disable-ipv6` as this turned-out to be important.  I did some tracing on DNS resolution from `dirmngr` and whenever it selected a specific IPv6 address from `ha.pool.sks-keyservers.net` it did not recover and failover to IPv4 like it otherwise did.

To add to the woes, it looks like Gentoo DNS-round-robin-based mirroring also has problems - I think it is to do with differing base URIs for mirrors and DNS is just shuffling the hosts.  Workaround for now is to lock to the OSU OSL mirror.  A bug should be logged on the DNS-based mirror setup because the paths are always going to differ.

Took the opportunity to bump the Alpine builder version to 3.7 (was not sufficient to fix `gpg` problem).

Fixed #53.