### PR TITLE
Extract stage3 archive using XZ compression

### DIFF
--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -18,7 +18,7 @@ ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/releases/${ARCH}/autobuilds"
 ARG SIGNING_KEY="0xBB572E0E2D182910"
 
 RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${DIST}" \
- && apk --no-cache add gnupg tar wget \
+ && apk --no-cache add gnupg tar wget xz\
  && STAGE3PATH="$(wget -O- "${DIST}/latest-stage3-${MICROARCH}${SUFFIX}.txt" | tail -n 1 | cut -f 1 -d ' ')" \
  && echo "STAGE3PATH:" $STAGE3PATH \
  && STAGE3="$(basename ${STAGE3PATH})" \
@@ -30,7 +30,7 @@ RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${
  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${STAGE3}.DIGESTS.asc" \
  && awk '/# SHA512 HASH/{getline; print}' ${STAGE3}.DIGESTS.asc | sha512sum -c \
- && tar xjpf "${STAGE3}" --xattrs --numeric-owner \
+ && tar xJpf "${STAGE3}" --xattrs --numeric-owner \
  && sed -i -e 's/#rc_sys=""/rc_sys="docker"/g' etc/rc.conf \
  && echo 'UTC' > etc/timezone \
  && rm ${STAGE3}.DIGESTS.asc ${STAGE3}.CONTENTS ${STAGE3}


### PR DESCRIPTION
Since official stage3 archives use XZ compression, we must adjust dockerfile in consequence.