### PR TITLE
Transparent mirror support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The container being built is defined by the TARGET environment variable:
 
 `` TARGET=stage3-amd64 ./build.sh ``
 
+## Specifying a stage3 mirror
+
+By default the script will import the highest priority Gentoo mirror specified by `GENTOO_MIRRORS` in `/etc/portage/make.conf`, or select a reasonable default. If you want to specify a particular mirror, you can do so as follows:
+
+`` DIST=http://mirror.address.here/gentoo/releases/${ARCH}/autobuilds TARGET=stage3-amd64 ./build.sh ``
+
 # Using the portage container as a data volume
 
 ```

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ if [[ -e /etc/portage/make.conf ]]; then
 		export DIST="${DIST}/releases/${ARCH}/autobuilds"
 		echo "DIST: using locally preferred mirror: '${DIST}'."
 	fi
-	DISTBUILDARG="--build-arg DIST=\"${DIST}\""
+	DISTBUILDARG="--build-arg DIST=${DIST}"
 fi
 
 docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}" ${DISTBUILDARG} -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .

--- a/build.sh
+++ b/build.sh
@@ -32,5 +32,14 @@ if [[ -n "${SUFFIX}" ]]; then
 	SUFFIX="-${SUFFIX}"
 fi
 
-docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}"  -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .
+# Load local mirror as DIST
+if [[ -e /etc/portage/make.conf ]]; then
+	export DIST=`grep 'GENTOO_MIRRORS="' /etc/portage/make.conf|cut -d '"' -f 2|cut -d ' ' -f1`
+	if [[ ${DIST} != "" ]]; then
+		export DIST="${DIST}/releases/${ARCH}/autobuilds"
+		echo "DIST: using locally preferred mirror: '${DIST}'."
+	fi
+fi
+
+docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}" --build-arg DIST="${DIST}" -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .
 docker tag "${ORG}/${TARGET}:${VERSION}" "${ORG}/${TARGET}:latest"

--- a/build.sh
+++ b/build.sh
@@ -35,8 +35,8 @@ fi
 # Load local mirror as DIST
 DISTBUILDARG=''
 if [[ -e /etc/portage/make.conf ]]; then
-	export DIST=`grep 'GENTOO_MIRRORS="' /etc/portage/make.conf|cut -d '"' -f 2|cut -d ' ' -f1`
-	if [[ ${DIST} != "" ]]; then
+	export DIST=`portageq envvar GENTOO_MIRRORS|cut -d '"' -f 2|cut -d ' ' -f1`
+	if [ ${DIST} ]; then
 		export DIST="${DIST}/releases/${ARCH}/autobuilds"
 		echo "DIST: using locally preferred mirror: '${DIST}'."
 	fi

--- a/build.sh
+++ b/build.sh
@@ -33,13 +33,15 @@ if [[ -n "${SUFFIX}" ]]; then
 fi
 
 # Load local mirror as DIST
+DISTBUILDARG=''
 if [[ -e /etc/portage/make.conf ]]; then
 	export DIST=`grep 'GENTOO_MIRRORS="' /etc/portage/make.conf|cut -d '"' -f 2|cut -d ' ' -f1`
 	if [[ ${DIST} != "" ]]; then
 		export DIST="${DIST}/releases/${ARCH}/autobuilds"
 		echo "DIST: using locally preferred mirror: '${DIST}'."
 	fi
+	DISTBUILDARG="--build-arg DIST=\"${DIST}\""
 fi
 
-docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}" --build-arg DIST="${DIST}" -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .
+docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}" ${DISTBUILDARG} -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .
 docker tag "${ORG}/${TARGET}:${VERSION}" "${ORG}/${TARGET}:latest"


### PR DESCRIPTION
I am in China where international mirrors are very slow and unreliable.

I suspect many other people would prefer if their execution defaulted to the locally selected mirror.

This pull request implements automated selection of the highest priority mirror specified in `/etc/portage/make.conf` but falls back gracefully to the current default mirror. It also adds documentation regarding this feature and manual mirror selection to `README.md`.