### PR TITLE
Corrected an example so the the container actually runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The container being built is defined by the TARGET environment variable:
 
 ```
 docker create -v /usr/portage --name myportagesnapshot gentoo/portage:latest /bin/true
-docker run --volumes-from myportagesnapshot gentoo/stage3-amd64:latest /bin/bash
+docker run --interactive --tty --volumes-from myportagesnapshot gentoo/stage3-amd64:latest /bin/bash
 ```
 
 # Using the portage container in a multi-stage build


### PR DESCRIPTION
- Not sure if this is just a typo or if the behavior has changed
  over time but the current "Using the portage container as a
  data volume" example exits immediately because bash has no
  stdin.

Signed-off-by: John R. Graham <john_r_graham@gentoo.org>