### PR TITLE
migrate portage location to default /var/db/repos/gentoo (fix #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ FROM gentoo/portage:latest as portage
 FROM gentoo/stage3-amd64:latest
 
 # copy the entire portage volume in
-COPY --from=portage /usr/portage /usr/portage
+COPY --from=portage /var/db/repos/gentoo /var/db/repos/gentoo
 
 # continue with image build ...
 RUN emerge -qv www-servers/apache # or whichever packages you need

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -23,8 +23,9 @@ RUN apk add --no-cache gnupg tar wget xz \
  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
  && gpg --verify "${SNAPSHOT}.gpgsig" "${SNAPSHOT}" \
  && md5sum -c ${SNAPSHOT}.md5sum \
- && mkdir -p usr/portage/distfiles usr/portage/packages \
- && tar xJpf ${SNAPSHOT} -C usr \
+ && mkdir -p var/db/repos var/cache/binpkgs var/cache/distfiles \
+ && tar xJpf ${SNAPSHOT} -C var/db/repos \
+ && mv var/db/repos/portage var/db/repos/gentoo \
  && rm ${SNAPSHOT} ${SNAPSHOT}.gpgsig ${SNAPSHOT}.md5sum
 
 FROM busybox:latest
@@ -32,4 +33,4 @@ FROM busybox:latest
 WORKDIR /
 COPY --from=builder /portage/ /
 CMD /bin/true
-VOLUME /usr/portage
+VOLUME /var/db/repos/gentoo


### PR DESCRIPTION
as reported by @MeisterP on #69 our current portage volume image does
not expose the portage tree in the default gentoo portage location
which changed from /usr/portage to /var/db/repos/gentoo

those defaults are reflected in /usr/share/portage/config/repos.conf
as installed by newer portage