### PR TITLE
Add a Dockerfile for a systemd image

### DIFF
--- a/stage3-systemd.Dockerfile
+++ b/stage3-systemd.Dockerfile
@@ -1,0 +1,42 @@
+# This Dockerfile creates a gentoo stage3 container image. By default it 
+# creates a stage3-amd64 image. It utilizes a multi-stage build and requires 
+# docker-17.05.0 or later. It fetches a daily snapshot from the official 
+# sources and verifies its checksum as well as its gpg signature.
+
+# As gpg keyservers sometimes are unreliable, we use multiple gpg server pools
+# to fetch the signing key.
+
+ARG BOOTSTRAP
+FROM ${BOOTSTRAP:-alpine:3.7} as builder
+
+WORKDIR /gentoo
+
+ARG ARCH=amd64
+ARG MICROARCH=amd64
+ARG SUFFIX=systemd
+ARG DIST="https://ftp-osl.osuosl.org/pub/gentoo/releases/${ARCH}/autobuilds"
+ARG SIGNING_KEY="0xBB572E0E2D182910"
+
+RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${DIST}" \
+ && apk --no-cache add gnupg tar wget xz \
+ && STAGE3PATH="$(wget -O- "${DIST}/latest-stage3-${MICROARCH}-${SUFFIX}.txt" | tail -n 1 | cut -f 1 -d ' ')" \
+ && echo "STAGE3PATH:" $STAGE3PATH \
+ && STAGE3="$(basename ${STAGE3PATH})" \
+ && wget -q "${DIST}/${STAGE3PATH}" "${DIST}/${STAGE3PATH}.CONTENTS" "${DIST}/${STAGE3PATH}.DIGESTS.asc" \
+ && gpg --list-keys \
+ && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
+ && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
+ && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${SIGNING_KEY} \
+ && gpg --verify "${STAGE3}.DIGESTS.asc" \
+ && awk '/# SHA512 HASH/{getline; print}' ${STAGE3}.DIGESTS.asc | sha512sum -c \
+ && tar xpf "${STAGE3}" --xattrs --numeric-owner \
+ && sed -i -e 's/#rc_sys=""/rc_sys="docker"/g' etc/rc.conf \
+ && echo 'UTC' > etc/timezone \
+ && rm ${STAGE3}.DIGESTS.asc ${STAGE3}.CONTENTS ${STAGE3}
+
+FROM scratch
+
+WORKDIR /
+COPY --from=builder /gentoo/ /
+CMD ["/bin/bash"]


### PR DESCRIPTION
There's no denying that for some applications, using the systemd tarball instead of the OpenRC one may be necessary ― so submitting a pull request for that.