### PR TITLE
#75: support for building more gentoo arches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker-copyedit"]
+	path = docker-copyedit
+	url = https://github.com/gdraheim/docker-copyedit.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,18 @@ env:
     - TARGET=stage3-amd64-systemd
     - TARGET=stage3-x86
     - TARGET=stage3-x86-hardened
+    - TARGET=stage3-armv7a
+    - TARGET=stage3-ppc
+    - TARGET=stage3-ppc64
+    - TARGET=stage3-ppc64le
 
 before_install:
   # Install docker 17.05.0 or later
   - sudo apt-get update -qq
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+  - sudo apt-get install qemu-user-static binfmt-support
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 script:
   - VERSION="$(date -u +%Y%m%d)"
   - sudo ./build.sh

--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+docker manifest create gentoo/stage3 \
+	gentoo/stage3-amd64  \
+	gentoo/stage3-x86    \
+	gentoo/stage3-armv7a \
+	gentoo/stage3-amd64  \
+	gentoo/stage3-ppc    \
+	gentoo/stage3-ppc64  \
+	gentoo/stage3-ppc64le

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,12 @@ ORG=${ORG:-gentoo}
 if [[ "${ARCH}" == "x86" ]]; then
 	MICROARCH="i686"
 	BOOTSTRAP="multiarch/alpine:x86-v3.7"
+elif [[ "${ARCH}" = ppc* ]]; then
+	MICROARCH="${ARCH}"
+	ARCH=ppc
+elif [[ "${ARCH}" = arm* ]]; then
+	MICROARCH="${ARCH}"
+	ARCH=arm
 else
 	MICROARCH="${ARCH}"
 fi
@@ -32,5 +38,6 @@ if [[ -n "${SUFFIX}" ]]; then
 	SUFFIX="-${SUFFIX}"
 fi
 
+set -x
 docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}"  -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .
 docker tag "${ORG}/${TARGET}:${VERSION}" "${ORG}/${TARGET}:latest"

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ fi
 
 # Split the TARGET variable into three elements separated by hyphens
 IFS=- read -r NAME ARCH SUFFIX <<< "${TARGET}"
+DOCKER_ARCH="${ARCH}"
 
 # Ensure upstream directories for stage3-amd64-hardened+nomultilib work
 SUFFIX=${SUFFIX/-/+}
@@ -21,12 +22,14 @@ ORG=${ORG:-gentoo}
 
 # x86 requires the i686 subfolder
 if [[ "${ARCH}" == "x86" ]]; then
+	DOCKER_ARCH="386"
 	MICROARCH="i686"
 	BOOTSTRAP="multiarch/alpine:x86-v3.7"
 elif [[ "${ARCH}" = ppc* ]]; then
 	MICROARCH="${ARCH}"
 	ARCH=ppc
 elif [[ "${ARCH}" = arm* ]]; then
+	DOCKER_ARCH=$(echo $ARCH | sed -e 's-\(v.\).*-/\1-g')
 	MICROARCH="${ARCH}"
 	ARCH=arm
 else
@@ -40,4 +43,6 @@ fi
 
 set -x
 docker build --build-arg ARCH="${ARCH}" --build-arg MICROARCH="${MICROARCH}" --build-arg BOOTSTRAP="${BOOTSTRAP}" --build-arg SUFFIX="${SUFFIX}"  -t "${ORG}/${TARGET}:${VERSION}" -f "${NAME}.Dockerfile" .
+docker-copyedit/docker-copyedit.py FROM "${ORG}/${TARGET}:${VERSION}" INTO "${ORG}/${TARGET}:${VERSION}" -vv \
+    set arch ${DOCKER_ARCH}
 docker tag "${ORG}/${TARGET}:${VERSION}" "${ORG}/${TARGET}:latest"


### PR DESCRIPTION
#75: Tweaks to `build.sh` to support passing in ppc/arm so that the FTP URL is valid.  Adding arm/ppc to travis.