### PR TITLE
Fix portage and stage3 generation

### DIFF
--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -3,7 +3,7 @@
 # docker-17.05.0 or later. It fetches a daily snapshot from the official
 # sources and verifies its checksum as well as its gpg signature.
 
-FROM alpine:3.7 as builder
+FROM alpine:3.11 as builder
 
 WORKDIR /portage
 

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -14,7 +14,6 @@ ARG SIGNING_KEY="0xEC590EEAC9189250"
 RUN apk add --no-cache ca-certificates gnupg tar wget xz \
  && wget -q "${DIST}/${SNAPSHOT}" "${DIST}/${SNAPSHOT}.gpgsig" "${DIST}/${SNAPSHOT}.md5sum" \
  && gpg --list-keys \
- && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
  && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg --keyserver hkps://keys.gentoo.org --recv-keys ${SIGNING_KEY} \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -21,7 +21,6 @@ RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${
  && STAGE3="$(basename ${STAGE3PATH})" \
  && wget -q "${DIST}/${STAGE3PATH}" "${DIST}/${STAGE3PATH}.CONTENTS" "${DIST}/${STAGE3PATH}.DIGESTS.asc" \
  && gpg --list-keys \
- && echo "standard-resolver" >> ~/.gnupg/dirmngr.conf \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
  && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg --keyserver hkps://keys.gentoo.org --recv-keys ${SIGNING_KEY} \

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -4,7 +4,7 @@
 # sources and verifies its checksum as well as its gpg signature.
 
 ARG BOOTSTRAP
-FROM ${BOOTSTRAP:-alpine:3.7} as builder
+FROM ${BOOTSTRAP:-alpine:3.11} as builder
 
 WORKDIR /gentoo
 


### PR DESCRIPTION
Removing standard-resolver enables keys to be fetched again, and image building will succeed.

Also, while at it lets bump Alpine from 3.7 to 3.11

Signed-off-by: Robert Marko <robimarko@gmail.com>