### PR TITLE
Remove deprecated `sudo` key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 services: docker
 language: bash
 env:


### PR DESCRIPTION
Travis CI has long deprecated the `sudo` key [1]; let's remove it in
order to silence any build config validation warnings.

[1] https://changelog.travis-ci.com/84517

Signed-off-by: Konstantinos Smanis <konstantinos.smanis@gmail.com>