### PR TITLE
Push all stage3 images and manifest lists to the same repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - ORG=gentoo
   jobs:
     - TARGET=portage
-    - TARGET=stage3-amd64
+    - TARGET=stage3-amd64 LATEST=true
     - TARGET=stage3-amd64-hardened
     - TARGET=stage3-amd64-hardened-nomultilib
     - TARGET=stage3-amd64-musl-hardened
@@ -44,7 +44,7 @@ script:
   - ./build.sh
 after_success:
   # Inspect built image
-  - docker image inspect "${ORG}/${TARGET}:latest"
+  - docker image inspect "${ORG}/${TARGET/-/:}"
   # Run `emerge --info` for stage builds
   - |
     if [[ "${TARGET}" == stage* ]]; then
@@ -53,11 +53,12 @@ after_success:
         # Enable execution of foreign binary formats (i.e., non-amd64/x86)
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
       fi
-      docker run --rm "${ORG}/${TARGET}:latest" emerge --info
+      docker run --rm "${ORG}/${TARGET/-/:}" emerge --info
     fi
   # Push all built images to Docker Hub (cron daily task)
   - |
     if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}" == "master" && "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
       echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-      docker push "${ORG}/${TARGET}"
+      REPO="$(cut -d '-' -f 1 <<< ${TARGET})"
+      docker push "${ORG}/${REPO}"
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
     - ORG=gentoo
   jobs:
     - TARGET=portage
-    - TARGET=stage3-amd64 LATEST=true
+    - TARGET=stage3-amd64
     - TARGET=stage3-amd64-hardened
     - TARGET=stage3-amd64-hardened-nomultilib
     - TARGET=stage3-amd64-musl-hardened
@@ -55,10 +55,10 @@ after_success:
       fi
       docker run --rm "${ORG}/${TARGET/-/:}" emerge --info
     fi
-  # Push all built images to Docker Hub (cron daily task)
-  - |
-    if [[ "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}" == "master" && "${TRAVIS_EVENT_TYPE}" == "cron" ]]; then
-      echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-      REPO="$(cut -d '-' -f 1 <<< ${TARGET})"
-      docker push "${ORG}/${REPO}"
-    fi
+deploy:
+  # Push to Docker Hub (daily cron job)
+  - provider: script
+    script: ./deploy.sh
+    on:
+      branch: master
+      condition: $TRAVIS_EVENT_TYPE = cron

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ https://hub.docker.com/u/gentoo/
 
 ## Inventory
 
-The following targets are built by Travis (bold targets are also pushed to Docker Hub):
- * **`portage`**
+The following targets are built by Travis and pushed to Docker Hub:
+ * `portage`
  * `stage3`
    * `amd64`
-     * **`stage3-amd64`**
-     * **`stage3-amd64-hardened`**
-     * **`stage3-amd64-hardened-nomultilib`**
+     * `stage3-amd64`
+     * `stage3-amd64-hardened`
+     * `stage3-amd64-hardened-nomultilib`
      * `stage3-amd64-musl-hardened`
      * `stage3-amd64-musl-vanilla`
-     * **`stage3-amd64-nomultilib`**
+     * `stage3-amd64-nomultilib`
      * `stage3-amd64-systemd`
      * `stage3-amd64-uclibc-hardened`
      * `stage3-amd64-uclibc-vanilla`
@@ -39,8 +39,8 @@ The following targets are built by Travis (bold targets are also pushed to Docke
    * `s390`
      * `stage3-s390x`
    * `x86`
-     * **`stage3-x86`**
-     * **`stage3-x86-hardened`**
+     * `stage3-x86`
+     * `stage3-x86-hardened`
      * `stage3-x86-musl-vanilla`
      * `stage3-x86-systemd`
      * `stage3-x86-uclibc-hardened`

--- a/build.sh
+++ b/build.sh
@@ -69,7 +69,6 @@ docker buildx build \
 	--build-arg SUFFIX="${SUFFIX}" \
 	--tag "${ORG}/${TARGET/-/:}" \
 	--tag "${ORG}/${TARGET/-/:}${VERSION_SUFFIX}" \
-	${LATEST:+--tag "${ORG}/${NAME}:latest"} \
 	--platform "linux/${DOCKER_ARCH}" \
 	--progress plain \
 	--load \

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,11 @@ fi
 IFS=- read -r NAME ARCH SUFFIX <<< "${TARGET}"
 
 VERSION=${VERSION:-$(date -u +%Y%m%d)}
+if [[ "${NAME}" == "portage" ]]; then
+	VERSION_SUFFIX=":${VERSION}"
+else
+	VERSION_SUFFIX="-${VERSION}"
+fi
 
 ORG=${ORG:-gentoo}
 
@@ -62,8 +67,9 @@ docker buildx build \
 	--build-arg ARCH="${ARCH}" \
 	--build-arg MICROARCH="${MICROARCH}" \
 	--build-arg SUFFIX="${SUFFIX}" \
-	--tag "${ORG}/${TARGET}:latest" \
-	--tag "${ORG}/${TARGET}:${VERSION}" \
+	--tag "${ORG}/${TARGET/-/:}" \
+	--tag "${ORG}/${TARGET/-/:}${VERSION_SUFFIX}" \
+	${LATEST:+--tag "${ORG}/${NAME}:latest"} \
 	--platform "linux/${DOCKER_ARCH}" \
 	--progress plain \
 	--load \

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [[ -z "$TARGET" ]]; then
+	echo "TARGET environment variable must be set e.g. TARGET=stage3-amd64."
+	exit 1
+fi
+
+# Split the TARGET variable into three elements separated by hyphens
+IFS=- read -r NAME ARCH SUFFIX <<< "${TARGET}"
+
+# Push built images
+echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
+docker push "${ORG}/${NAME}"
+
+if [[ "${TARGET}" != stage* ]]; then
+	echo "Done! No manifests to push for TARGET=${TARGET}."
+	exit 0
+fi
+
+VERSION=${VERSION:-$(date -u +%Y%m%d)}
+
+declare -A MANIFEST_ARCHES=(
+	[stage3:latest]="amd64;arm64;armv5tel;armv6j_hardfp;armv7a_hardfp;ppc64le;s390x;x86"
+	[stage3:hardened]="amd64;x86"
+	[stage3:hardened-nomultilib]="amd64"
+	[stage3:musl-hardened]="amd64"
+	[stage3:musl-vanilla]="amd64;x86"
+	[stage3:nomultilib]="amd64"
+	[stage3:systemd]="amd64;arm64;x86"
+	[stage3:uclibc-hardened]="amd64;x86"
+	[stage3:uclibc-vanilla]="amd64;x86"
+)
+
+# Latest manifests
+MANIFEST="${NAME}:${SUFFIX:-latest}"
+IFS=';' read -ra ARCHES <<< "${MANIFEST_ARCHES[${MANIFEST}]}"
+
+TAGS=()
+for ARCH in "${ARCHES[@]}"; do
+	TAGS+=("${ORG}/${NAME}:${ARCH}${SUFFIX:+-${SUFFIX}}")
+done
+
+docker manifest create "${ORG}/${MANIFEST}" "${TAGS[@]}"
+docker manifest push "${ORG}/${MANIFEST}"
+
+# Dated manifests
+MANIFEST="${NAME}:${SUFFIX:+${SUFFIX}-}${VERSION}"
+
+TAGS=()
+for ARCH in "${ARCHES[@]}"; do
+	TAGS+=("${ORG}/${NAME}:${ARCH}${SUFFIX:+-${SUFFIX}}-${VERSION}")
+done
+
+docker manifest create "${ORG}/${MANIFEST}" "${TAGS[@]}"
+docker manifest push "${ORG}/${MANIFEST}"


### PR DESCRIPTION
Commits should not be squashed. First commit implements option 2 as discussed in #86, while the second commit implements option 3 on top of that.

Reference build results can be found at [ksmanis/portage](https://hub.docker.com/r/ksmanis/portage/tags) and [ksmanis/stage3](https://hub.docker.com/r/ksmanis/stage3/tags).