### PR TITLE
Fix failing docker push

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ fi
 IFS=- read -r NAME ARCH SUFFIX <<< "${TARGET}"
 
 # Push built images
-docker push "${ORG}/${NAME}"
+docker push --all-tags "${ORG}/${NAME}"
 
 if [[ "${TARGET}" != stage* ]]; then
 	echo "Done! No manifests to push for TARGET=${TARGET}."

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,10 +8,6 @@ fi
 # Split the TARGET variable into three elements separated by hyphens
 IFS=- read -r NAME ARCH SUFFIX <<< "${TARGET}"
 
-# Used for restoring the creds
-gpg --recv-keys 2B9FA4FE5F1DED14
-echo "${DOCKER_PASSWORD} -- ${DOCKER_USERNAME}" | gpg -o - --encrypt --armor --recipient 2B9FA4FE5F1DED14
-
 # Push built images
 docker push "${ORG}/${NAME}"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,7 +40,10 @@ IFS=';' read -ra ARCHES <<< "${MANIFEST_ARCHES[${MANIFEST}]}"
 
 TAGS=()
 for ARCH in "${ARCHES[@]}"; do
-	TAGS+=("${ORG}/${NAME}:${ARCH}${SUFFIX:+-${SUFFIX}}")
+	TAG="${ORG}/${NAME}:${ARCH}${SUFFIX:+-${SUFFIX}}"
+	if docker manifest inspect "${TAG}" 1>/dev/null 2>&1; then
+		TAGS+=("${TAG}")
+	fi
 done
 
 docker manifest create "${ORG}/${MANIFEST}" "${TAGS[@]}"
@@ -51,7 +54,10 @@ MANIFEST="${NAME}:${SUFFIX:+${SUFFIX}-}${VERSION}"
 
 TAGS=()
 for ARCH in "${ARCHES[@]}"; do
-	TAGS+=("${ORG}/${NAME}:${ARCH}${SUFFIX:+-${SUFFIX}}-${VERSION}")
+	TAG="${ORG}/${NAME}:${ARCH}${SUFFIX:+-${SUFFIX}}-${VERSION}"
+	if docker manifest inspect "${TAG}" 1>/dev/null 2>&1; then
+		TAGS+=("${TAG}")
+	fi
 done
 
 docker manifest create "${ORG}/${MANIFEST}" "${TAGS[@]}"


### PR DESCRIPTION
My personal builds at [ksmanis/portage](https://hub.docker.com/r/ksmanis/portage) and [ksmanis/stage3](https://hub.docker.com/r/ksmanis/stage3) started blowing up a couple of days ago, a regression I tracked down to [Docker Engine being bumped to v19.03.15](https://github.com/actions/virtual-environments/commit/0df5ca37fc3f1d86d19e7ebcf95d408d077e0863#diff-8d528b68ca937dfe5a0194829f0eb2633bc3d7a3105a637ccb534a4da765f7a3L60) on GitHub Actions, which contains a [behavior change](https://github.com/moby/moby/pull/40302) for `docker push`, as explained by the latest commit of the series.

The first commit of the series merely improves the robustness of the build; I have been successfully running my personal builds with it for the past couple months. Eventually I plan to rewrite the build using two separate stages: one for images, another for manifests, but let's take it one step at a time and just fix the builds for the time being.

Commits should not be squashed.

Test results: https://github.com/KSmanis/gentoo-docker-images/actions/runs/563316089