### PR TITLE
Add support for systemd and musl-hardened profiles to ppc64le.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
           - stage3-armv6j_hardfp
           - stage3-armv7a_hardfp
           - stage3-ppc64le
+          - stage3-ppc64le-musl-hardened
+          - stage3-ppc64le-systemd
           - stage3-s390x
           - stage3-x86
           - stage3-x86-hardened

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,10 +22,10 @@ declare -A MANIFEST_ARCHES=(
 	[stage3:latest]="amd64;arm64;armv5tel;armv6j_hardfp;armv7a_hardfp;ppc64le;s390x;x86"
 	[stage3:hardened]="amd64;x86"
 	[stage3:hardened-nomultilib]="amd64"
-	[stage3:musl-hardened]="amd64"
+	[stage3:musl-hardened]="amd64;ppc64le"
 	[stage3:musl-vanilla]="amd64;x86"
 	[stage3:nomultilib]="amd64"
-	[stage3:systemd]="amd64;arm64;x86"
+	[stage3:systemd]="amd64;arm64;x86;ppc64le"
 	[stage3:uclibc-hardened]="amd64;x86"
 	[stage3:uclibc-vanilla]="amd64;x86"
 )


### PR DESCRIPTION
This commit adds support for deployment of `stage3-ppc64le-musl-hardened` and `stage3-ppc64le-systemd` images and adds them to the automated workflow.

Currently there seem to be no `musl-hardened` and `systemd` variants for `gentoo/stage3:ppc64le`, even though there are stage3s available and updated in upstream. I cant find mention of these images in the README nor in the rationale. Both these images build fine, so I think adding them is a good idea.