### PR TITLE
Add stage3:desktop (just amd64-desktop-openrc for now)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           - stage3-amd64-nomultilib-openrc
           - stage3-amd64-nomultilib-systemd
           - stage3-amd64-openrc
+          - stage3-amd64-desktop-openrc
           - stage3-amd64-systemd
           - stage3-armv5tel-openrc
           - stage3-armv5tel-systemd

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following targets are built and pushed to Docker Hub:
      * `stage3-amd64-nomultilib-openrc`
      * `stage3-amd64-nomultilib-systemd`
      * `stage3-amd64-openrc`
+     * `stage3-amd64-desktop-openrc`
      * `stage3-amd64-systemd`
    * `arm`
      * `stage3-armv5tel-openrc`

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,6 +17,7 @@ docker push --all-tags "${ORG}/${NAME}"
 
 declare -A MANIFEST_TAGS=(
 	[stage3:latest]="amd64-openrc;armv5tel-openrc;armv6j_hardfp-openrc;armv7a_hardfp-openrc;arm64;i686-openrc;ppc64le-openrc;rv64_lp64d-openrc;s390x"
+	[stage3:desktop]="amd64-desktop-openrc"
 	[stage3:hardened]="amd64-hardened-openrc;i686-hardened-openrc"
 	[stage3:hardened-nomultilib]="amd64-hardened-nomultilib-openrc"
 	[stage3:musl]="amd64-musl;i686-musl"


### PR DESCRIPTION
In particular, this is useful for CI for upstreams who don't
want to have to build X etc just to run their test suite.

Signed-off-by: Sam James <sam@gentoo.org>