### PR TITLE
Switch systemd images to mergedusr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,43 +21,41 @@ jobs:
           - stage3-amd64-musl
           - stage3-amd64-musl-hardened
           - stage3-amd64-nomultilib-openrc
-          - stage3-amd64-nomultilib-systemd
+          - stage3-amd64-nomultilib-systemd-mergedusr
           - stage3-amd64-openrc
           - stage3-amd64-desktop-openrc
-          - stage3-amd64-systemd
           - stage3-amd64-systemd-mergedusr
-          - stage3-amd64-desktop-systemd
           - stage3-amd64-desktop-systemd-mergedusr
           - stage3-armv5tel-openrc
-          - stage3-armv5tel-systemd
+          - stage3-armv5tel-systemd-mergedusr
           - stage3-armv6j-openrc
-          - stage3-armv6j-systemd
+          - stage3-armv6j-systemd-mergedusr
           - stage3-armv6j_hardfp-openrc
-          - stage3-armv6j_hardfp-systemd
+          - stage3-armv6j_hardfp-systemd-mergedusr
           - stage3-armv7a-openrc
-          - stage3-armv7a-systemd
+          - stage3-armv7a-systemd-mergedusr
           - stage3-armv7a_hardfp_musl-openrc
           - stage3-armv7a_hardfp-openrc
-          - stage3-armv7a_hardfp-systemd
+          - stage3-armv7a_hardfp-systemd-mergedusr
           - stage3-arm64-desktop-openrc
-          - stage3-arm64-desktop-systemd
+          - stage3-arm64-desktop-systemd-mergedusr
           - stage3-arm64-musl
           - stage3-arm64-musl-hardened
           - stage3-arm64-openrc
-          - stage3-arm64-systemd
+          - stage3-arm64-systemd-mergedusr
           - stage3-i686-hardened-openrc
           - stage3-i686-musl
           - stage3-i686-openrc
-          - stage3-i686-systemd
+          - stage3-i686-systemd-mergedusr
           - stage3-ppc64le-musl-hardened-openrc
           - stage3-ppc64le-openrc
-          - stage3-ppc64le-systemd
+          - stage3-ppc64le-systemd-mergedusr
           - stage3-rv64_lp64-openrc
-          - stage3-rv64_lp64-systemd
+          - stage3-rv64_lp64-systemd-mergedusr
           - stage3-rv64_lp64d-openrc
-          - stage3-rv64_lp64d-systemd
+          - stage3-rv64_lp64d-systemd-mergedusr
           - stage3-s390x-openrc
-          - stage3-s390x-systemd
+          - stage3-s390x-systemd-mergedusr
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -23,48 +23,46 @@ The following targets are built and pushed to Docker Hub:
      * `stage3-amd64-musl`
      * `stage3-amd64-musl-hardened`
      * `stage3-amd64-nomultilib-openrc`
-     * `stage3-amd64-nomultilib-systemd`
+     * `stage3-amd64-nomultilib-systemd-mergedusr`
      * `stage3-amd64-openrc`
      * `stage3-amd64-desktop-openrc`
-     * `stage3-amd64-systemd`
      * `stage3-amd64-systemd-mergedusr`
-     * `stage3-amd64-desktop-systemd`
      * `stage3-amd64-desktop-systemd-mergedusr`
    * `arm`
      * `stage3-armv5tel-openrc`
-     * `stage3-armv5tel-systemd`
+     * `stage3-armv5tel-systemd-mergedusr`
      * `stage3-armv6j-openrc`
-     * `stage3-armv6j-systemd`
+     * `stage3-armv6j-systemd-mergedusr`
      * `stage3-armv6j_hardfp-openrc`
-     * `stage3-armv6j_hardfp-systemd`
+     * `stage3-armv6j_hardfp-systemd-mergedusr`
      * `stage3-armv7a-openrc`
-     * `stage3-armv7a-systemd`
+     * `stage3-armv7a-systemd-mergedusr`
      * `stage3-armv7a_hardfp_musl-openrc`
      * `stage3-armv7a_hardfp-openrc`
-     * `stage3-armv7a_hardfp-systemd`
+     * `stage3-armv7a_hardfp-systemd-mergedusr`
    * `arm64`
      * `stage3-arm64-desktop-openrc`
-     * `stage3-arm64-desktop-systemd`
+     * `stage3-arm64-desktop-systemd-mergedusr`
      * `stage3-arm64-musl`
      * `stage3-arm64-musl-hardened`
      * `stage3-arm64-openrc`
-     * `stage3-arm64-systemd`
+     * `stage3-arm64-systemd-mergedusr`
    * `ppc`
      * `stage3-ppc64le-musl-hardened-openrc`
      * `stage3-ppc64le-openrc`
-     * `stage3-ppc64le-systemd`
+     * `stage3-ppc64le-systemd-mergedusr`
    * `riscv`
      * `stage3-rv64_lp64-openrc`
-     * `stage3-rv64_lp64-systemd`
+     * `stage3-rv64_lp64-systemd-mergedusr`
      * `stage3-rv64_lp64d-openrc`
-     * `stage3-rv64_lp64d-systemd`
+     * `stage3-rv64_lp64d-systemd-mergedusr`
    * `s390`
      * `stage3-s390x`
    * `x86`
      * `stage3-i686-hardened-openrc`
      * `stage3-i686-musl`
      * `stage3-i686-openrc`
-     * `stage3-i686-systemd`
+     * `stage3-i686-systemd-mergedusr`
 
 The following upstream stage3 targets are not built at all:
  * `amd64`
@@ -83,17 +81,17 @@ The following upstream stage3 targets are not built at all:
    * `stage3-x32-openrc` [[unsupported](#unsupported)]
  * `arm`
    * `stage3-armv4tl` [[unsupported](#unsupported)]
-   * `stage3-armv4tl-systemd` [[unsupported](#unsupported)]
+   * `stage3-armv4tl-systemd-mergedusr` [[unsupported](#unsupported)]
  * `ppc`
    * `stage3-power9le-openrc` [[unsupported](#unsupported)]
-   * `stage3-power9le-systemd` [[unsupported](#unsupported)]
+   * `stage3-power9le-systemd-mergedusr` [[unsupported](#unsupported)]
    * `stage3-ppc` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-ppc-openrc` [[unsupported](#unsupported)]
    * `stage3-ppc64` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-ppc64-musl-hardened` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-ppc64-musl-hardened-openrc` [[unsupported](#unsupported)]
    * `stage3-ppc64-openrc` [[unsupported](#unsupported)]
-   * `stage3-ppc64-systemd` [[unsupported](#unsupported)]
+   * `stage3-ppc64-systemd-mergedusr` [[unsupported](#unsupported)]
    * `stage3-ppc64le` [[deprecated](#deprecated)]
    * `stage3-ppc64le-musl-hardened` [[deprecated](#deprecated)]
  * `riscv`

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ The following upstream stage3 targets are not built at all:
    * `stage3-amd64-musl-vanilla` [[deprecated](#deprecated)]
    * `stage3-amd64-nomultilib` [[deprecated](#deprecated)]
    * `stage3-amd64-nomultilib-selinux-openrc` [[selinux](#selinux)]
-   * `stage3-amd64-uclibc-hardened` [[deprecated](#deprecated)]
-   * `stage3-amd64-uclibc-vanilla` [[deprecated](#deprecated)]
    * `stage3-x32` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-x32-openrc` [[unsupported](#unsupported)]
  * `arm`
@@ -105,8 +103,6 @@ The following upstream stage3 targets are not built at all:
    * `stage3-i686` [[deprecated](#deprecated)]
    * `stage3-i686-hardened` [[deprecated](#deprecated)]
    * `stage3-i686-musl-vanilla` [[deprecated](#deprecated)]
-   * `stage3-i686-uclibc-hardened` [[deprecated](#deprecated)]
-   * `stage3-i686-uclibc-vanilla` [[deprecated](#deprecated)]
 
 <a name="deprecated">[deprecated]</a>: Deprecated stage3 target
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,14 +17,14 @@ docker push --all-tags "${ORG}/${NAME}"
 
 declare -A MANIFEST_TAGS=(
 	[stage3:latest]="amd64-openrc;armv5tel-openrc;armv6j_hardfp-openrc;armv7a_hardfp-openrc;arm64-openrc;i686-openrc;ppc64le-openrc;rv64_lp64d-openrc;s390x"
-	[stage3:desktop]="amd64-desktop-openrc;amd64-desktop-systemd;amd64-desktop-systemd-mergedusr;arm64-desktop-openrc"
+	[stage3:desktop]="amd64-desktop-openrc;arm64-desktop-openrc"
 	[stage3:hardened]="amd64-hardened-openrc;i686-hardened-openrc"
 	[stage3:hardened-nomultilib]="amd64-hardened-nomultilib-openrc"
 	[stage3:musl]="amd64-musl;armv7a_hardfp_musl-openrc;arm64-musl;i686-musl"
 	[stage3:musl-hardened]="amd64-musl-hardened;arm64-musl-hardened;ppc64le-musl-hardened-openrc"
 	[stage3:nomultilib]="amd64-nomultilib-openrc"
 	[stage3:nomultilib-systemd]="amd64-nomultilib-systemd"
-	[stage3:systemd]="amd64-systemd;amd64-systemd-mergedusr;armv5tel-systemd;armv6j_hardfp-systemd;armv7a_hardfp-systemd;arm64-systemd;i686-systemd;ppc64le-systemd;rv64_lp64d-systemd"
+	[stage3:systemd]="amd64-systemd;armv5tel-systemd;armv6j_hardfp-systemd;armv7a_hardfp-systemd;arm64-systemd;i686-systemd;ppc64le-systemd;rv64_lp64d-systemd"
 )
 
 # Find latest manifest

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,14 +17,14 @@ docker push --all-tags "${ORG}/${NAME}"
 
 declare -A MANIFEST_TAGS=(
 	[stage3:latest]="amd64-openrc;armv5tel-openrc;armv6j_hardfp-openrc;armv7a_hardfp-openrc;arm64-openrc;i686-openrc;ppc64le-openrc;rv64_lp64d-openrc;s390x"
-	[stage3:desktop]="amd64-desktop-openrc;arm64-desktop-openrc"
+	[stage3:desktop]="amd64-desktop-openrc;amd64-desktop-systemd;amd64-desktop-systemd-mergedusr;arm64-desktop-openrc"
 	[stage3:hardened]="amd64-hardened-openrc;i686-hardened-openrc"
 	[stage3:hardened-nomultilib]="amd64-hardened-nomultilib-openrc"
 	[stage3:musl]="amd64-musl;armv7a_hardfp_musl-openrc;arm64-musl;i686-musl"
 	[stage3:musl-hardened]="amd64-musl-hardened;arm64-musl-hardened;ppc64le-musl-hardened-openrc"
 	[stage3:nomultilib]="amd64-nomultilib-openrc"
 	[stage3:nomultilib-systemd]="amd64-nomultilib-systemd"
-	[stage3:systemd]="amd64-systemd;armv5tel-systemd;armv6j_hardfp-systemd;armv7a_hardfp-systemd;arm64-systemd;i686-systemd;ppc64le-systemd;rv64_lp64d-systemd"
+	[stage3:systemd]="amd64-systemd;amd64-systemd-mergedusr;armv5tel-systemd;armv6j_hardfp-systemd;armv7a_hardfp-systemd;arm64-systemd;i686-systemd;ppc64le-systemd;rv64_lp64d-systemd"
 )
 
 # Find latest manifest

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,8 +23,8 @@ declare -A MANIFEST_TAGS=(
 	[stage3:musl]="amd64-musl;armv7a_hardfp_musl-openrc;arm64-musl;i686-musl"
 	[stage3:musl-hardened]="amd64-musl-hardened;arm64-musl-hardened;ppc64le-musl-hardened-openrc"
 	[stage3:nomultilib]="amd64-nomultilib-openrc"
-	[stage3:nomultilib-systemd]="amd64-nomultilib-systemd"
-	[stage3:systemd]="amd64-systemd;armv5tel-systemd;armv6j_hardfp-systemd;armv7a_hardfp-systemd;arm64-systemd;i686-systemd;ppc64le-systemd;rv64_lp64d-systemd"
+	[stage3:nomultilib-systemd]="amd64-nomultilib-systemd-mergedusr"
+	[stage3:systemd]="amd64-systemd-mergedusr;armv5tel-systemd-mergedusr;armv6j_hardfp-systemd-mergedusr;armv7a_hardfp-systemd-mergedusr;arm64-systemd-mergedusr;i686-systemd-mergedusr;ppc64le-systemd-mergedusr;rv64_lp64d-systemd-mergedusr"
 )
 
 # Find latest manifest

--- a/portage.Dockerfile
+++ b/portage.Dockerfile
@@ -3,7 +3,7 @@
 # docker-17.05.0 or later. It fetches a daily snapshot from the official
 # sources and verifies its checksum as well as its gpg signature.
 
-FROM --platform=$BUILDPLATFORM alpine:3.11 as builder
+FROM --platform=$BUILDPLATFORM alpine:3.19 as builder
 
 WORKDIR /portage
 

--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -4,7 +4,7 @@
 # sources and verifies its checksum as well as its gpg signature.
 
 ARG BOOTSTRAP
-FROM --platform=$BUILDPLATFORM ${BOOTSTRAP:-alpine:3.11} as builder
+FROM --platform=$BUILDPLATFORM ${BOOTSTRAP:-alpine:3.19} as builder
 
 WORKDIR /gentoo
 


### PR DESCRIPTION
Switch systemd images to mergedusr

In bug #917143, we stopped building non-merged-usr stage3s following the
2022-12-01-systemd-usrmerge news item a while prior, as upstream systemd
no longer support non-merged-usr.

The stages for systemd w/ non-merged-usr are no being built, so the last one
we picked up was stage3-amd64-systemd-20231210T170356Z.tar.xz (and so on).

Switch all systemd images accordingly to merged-usr.

Bug: https://bugs.gentoo.org/915958
Bug: https://bugs.gentoo.org/917143
Closes: https://github.com/gentoo/gentoo-docker-images/issues/136
Signed-off-by: Sam James <sam@gentoo.org>
