### PR TITLE
actions: also push to Dockerhub on push

### DIFF
--- a/.github/actions/container_build/action.yml
+++ b/.github/actions/container_build/action.yml
@@ -35,14 +35,14 @@ runs:
     - name: Login to DockerHub
       uses: docker/login-action@v2
       if: |
-        github.repository_owner == 'gentoo' &&
+        github.ref_name == 'master' && github.repository_owner == 'gentoo' &&
         (github.event_name == 'schedule' || github.event_name == 'push')
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}
     - name: Push image
       if: |
-        github.repository_owner == 'gentoo' &&
+        github.ref_name == 'master' && github.repository_owner == 'gentoo' &&
         (github.event_name == 'schedule' || github.event_name == 'push')
       shell: bash
       env:

--- a/.github/actions/container_build/action.yml
+++ b/.github/actions/container_build/action.yml
@@ -34,12 +34,16 @@ runs:
       run: docker run --rm "${ORG}/${TARGET/-/:}" emerge --info
     - name: Login to DockerHub
       uses: docker/login-action@v2
-      if: github.event_name == 'schedule'
+      if: |
+        github.repository_owner == 'gentoo' &&
+        (github.event_name == 'schedule' || github.event_name == 'push')
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}
     - name: Push image
-      if: github.event_name == 'schedule'
+      if: |
+        github.repository_owner == 'gentoo' &&
+        (github.event_name == 'schedule' || github.event_name == 'push')
       shell: bash
       env:
         DOCKER_CLI_EXPERIMENTAL: enabled


### PR DESCRIPTION
Limiting Dockerhub pushes to "scheduled" Actions runs was intended to prevent these bits from running in PRs, but we also want changes to be applied for regular pushes to the repository, so we allow 'push'. To avoid this failing in forks without the requisite secrets, we also limit these to repositories in Gentoo's namespace.