### PR TITLE
stage3.Dockerfile: try harder to find releng's gpg key

### DIFF
--- a/stage3.Dockerfile
+++ b/stage3.Dockerfile
@@ -19,7 +19,8 @@ RUN echo "Building Gentoo Container image for ${ARCH} ${SUFFIX} fetching from ${
  && gpg --list-keys \
  && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
  && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg --keyserver hkps://keys.gentoo.org --recv-keys ${SIGNING_KEY} \
+ && gpg --keyserver hkps://keys.gentoo.org --recv-keys ${SIGNING_KEY} || \
+	gpg --auto-key-locate=clear,nodefault,wkd --locate-key releng@gentoo.org \
  && wget -q "${DIST}/latest-stage3-${MICROARCH}${SUFFIX}.txt" \
  && gpg --verify "latest-stage3-${MICROARCH}${SUFFIX}.txt" \
  && STAGE3PATH="$(sed -n '6p' "latest-stage3-${MICROARCH}${SUFFIX}.txt" | cut -f 1 -d ' ')" \


### PR DESCRIPTION
On a recent build action, we got:
```
1.106 gpg: directory '/root/.gnupg' created
1.107 gpg: /root/.gnupg/trustdb.gpg: trustdb created
64.28 gpg: keyserver receive failed: Operation timed out
```

Try to use gpg --auto-key-locate=clear,nodefault,wkd --locate-key releng@gentoo.org like we do in the handbook as a fallback.