### PR TITLE
Rename systemd-mergedusr to systemd 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,41 +21,41 @@ jobs:
           - stage3-amd64-musl
           - stage3-amd64-musl-hardened
           - stage3-amd64-nomultilib-openrc
-          - stage3-amd64-nomultilib-systemd-mergedusr
+          - stage3-amd64-nomultilib-systemd
           - stage3-amd64-openrc
           - stage3-amd64-desktop-openrc
-          - stage3-amd64-systemd-mergedusr
-          - stage3-amd64-desktop-systemd-mergedusr
+          - stage3-amd64-systemd
+          - stage3-amd64-desktop-systemd
           - stage3-armv5tel-openrc
-          - stage3-armv5tel-systemd-mergedusr
+          - stage3-armv5tel-systemd
           - stage3-armv6j-openrc
-          - stage3-armv6j-systemd-mergedusr
+          - stage3-armv6j-systemd
           - stage3-armv6j_hardfp-openrc
-          - stage3-armv6j_hardfp-systemd-mergedusr
+          - stage3-armv6j_hardfp-systemd
           - stage3-armv7a-openrc
-          - stage3-armv7a-systemd-mergedusr
+          - stage3-armv7a-systemd
           - stage3-armv7a_hardfp_musl-openrc
           - stage3-armv7a_hardfp-openrc
-          - stage3-armv7a_hardfp-systemd-mergedusr
+          - stage3-armv7a_hardfp-systemd
           - stage3-arm64-desktop-openrc
-          - stage3-arm64-desktop-systemd-mergedusr
+          - stage3-arm64-desktop-systemd
           - stage3-arm64-musl
           - stage3-arm64-musl-hardened
           - stage3-arm64-openrc
-          - stage3-arm64-systemd-mergedusr
+          - stage3-arm64-systemd
           - stage3-i686-hardened-openrc
           - stage3-i686-musl
           - stage3-i686-openrc
-          - stage3-i686-systemd-mergedusr
+          - stage3-i686-systemd
           - stage3-ppc64le-musl-hardened-openrc
           - stage3-ppc64le-openrc
-          - stage3-ppc64le-systemd-mergedusr
+          - stage3-ppc64le-systemd
           - stage3-rv64_lp64-openrc
-          - stage3-rv64_lp64-systemd-mergedusr
+          - stage3-rv64_lp64-systemd
           - stage3-rv64_lp64d-openrc
-          - stage3-rv64_lp64d-systemd-mergedusr
+          - stage3-rv64_lp64d-systemd
           - stage3-s390x-openrc
-          - stage3-s390x-systemd-mergedusr
+          - stage3-s390x-systemd
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The following upstream stage3 targets are not built at all:
 The containers are created using a multi-stage build, which requires Docker >= 19.03.0.
 The container being built is defined by the TARGET environment variable:
 
-`` TARGET=stage3-amd64 ./build.sh ``
+`` TARGET=stage3-amd64-openrc ./build.sh ``
 
 # Using the portage container as a data volume
 

--- a/README.md
+++ b/README.md
@@ -23,46 +23,46 @@ The following targets are built and pushed to Docker Hub:
      * `stage3-amd64-musl`
      * `stage3-amd64-musl-hardened`
      * `stage3-amd64-nomultilib-openrc`
-     * `stage3-amd64-nomultilib-systemd-mergedusr`
+     * `stage3-amd64-nomultilib-systemd`
      * `stage3-amd64-openrc`
      * `stage3-amd64-desktop-openrc`
-     * `stage3-amd64-systemd-mergedusr`
-     * `stage3-amd64-desktop-systemd-mergedusr`
+     * `stage3-amd64-systemd`
+     * `stage3-amd64-desktop-systemd`
    * `arm`
      * `stage3-armv5tel-openrc`
-     * `stage3-armv5tel-systemd-mergedusr`
+     * `stage3-armv5tel-systemd`
      * `stage3-armv6j-openrc`
-     * `stage3-armv6j-systemd-mergedusr`
+     * `stage3-armv6j-systemd`
      * `stage3-armv6j_hardfp-openrc`
-     * `stage3-armv6j_hardfp-systemd-mergedusr`
+     * `stage3-armv6j_hardfp-systemd`
      * `stage3-armv7a-openrc`
-     * `stage3-armv7a-systemd-mergedusr`
+     * `stage3-armv7a-systemd`
      * `stage3-armv7a_hardfp_musl-openrc`
      * `stage3-armv7a_hardfp-openrc`
-     * `stage3-armv7a_hardfp-systemd-mergedusr`
+     * `stage3-armv7a_hardfp-systemd`
    * `arm64`
      * `stage3-arm64-desktop-openrc`
-     * `stage3-arm64-desktop-systemd-mergedusr`
+     * `stage3-arm64-desktop-systemd`
      * `stage3-arm64-musl`
      * `stage3-arm64-musl-hardened`
      * `stage3-arm64-openrc`
-     * `stage3-arm64-systemd-mergedusr`
+     * `stage3-arm64-systemd`
    * `ppc`
      * `stage3-ppc64le-musl-hardened-openrc`
      * `stage3-ppc64le-openrc`
-     * `stage3-ppc64le-systemd-mergedusr`
+     * `stage3-ppc64le-systemd`
    * `riscv`
      * `stage3-rv64_lp64-openrc`
-     * `stage3-rv64_lp64-systemd-mergedusr`
+     * `stage3-rv64_lp64-systemd`
      * `stage3-rv64_lp64d-openrc`
-     * `stage3-rv64_lp64d-systemd-mergedusr`
+     * `stage3-rv64_lp64d-systemd`
    * `s390`
      * `stage3-s390x`
    * `x86`
      * `stage3-i686-hardened-openrc`
      * `stage3-i686-musl`
      * `stage3-i686-openrc`
-     * `stage3-i686-systemd-mergedusr`
+     * `stage3-i686-systemd`
 
 The following upstream stage3 targets are not built at all:
  * `amd64`
@@ -79,17 +79,17 @@ The following upstream stage3 targets are not built at all:
    * `stage3-x32-openrc` [[unsupported](#unsupported)]
  * `arm`
    * `stage3-armv4tl` [[unsupported](#unsupported)]
-   * `stage3-armv4tl-systemd-mergedusr` [[unsupported](#unsupported)]
+   * `stage3-armv4tl-systemd` [[unsupported](#unsupported)]
  * `ppc`
    * `stage3-power9le-openrc` [[unsupported](#unsupported)]
-   * `stage3-power9le-systemd-mergedusr` [[unsupported](#unsupported)]
+   * `stage3-power9le-systemd` [[unsupported](#unsupported)]
    * `stage3-ppc` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-ppc-openrc` [[unsupported](#unsupported)]
    * `stage3-ppc64` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-ppc64-musl-hardened` [[deprecated](#deprecated), [unsupported](#unsupported)]
    * `stage3-ppc64-musl-hardened-openrc` [[unsupported](#unsupported)]
    * `stage3-ppc64-openrc` [[unsupported](#unsupported)]
-   * `stage3-ppc64-systemd-mergedusr` [[unsupported](#unsupported)]
+   * `stage3-ppc64-systemd` [[unsupported](#unsupported)]
    * `stage3-ppc64le` [[deprecated](#deprecated)]
    * `stage3-ppc64le-musl-hardened` [[deprecated](#deprecated)]
  * `riscv`

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,8 +23,8 @@ declare -A MANIFEST_TAGS=(
 	[stage3:musl]="amd64-musl;armv7a_hardfp_musl-openrc;arm64-musl;i686-musl"
 	[stage3:musl-hardened]="amd64-musl-hardened;arm64-musl-hardened;ppc64le-musl-hardened-openrc"
 	[stage3:nomultilib]="amd64-nomultilib-openrc"
-	[stage3:nomultilib-systemd]="amd64-nomultilib-systemd-mergedusr"
-	[stage3:systemd]="amd64-systemd-mergedusr;armv5tel-systemd-mergedusr;armv6j_hardfp-systemd-mergedusr;armv7a_hardfp-systemd-mergedusr;arm64-systemd-mergedusr;i686-systemd-mergedusr;ppc64le-systemd-mergedusr;rv64_lp64d-systemd-mergedusr"
+	[stage3:nomultilib-systemd]="amd64-nomultilib-systemd"
+	[stage3:systemd]="amd64-systemd;armv5tel-systemd;armv6j_hardfp-systemd;armv7a_hardfp-systemd;arm64-systemd;i686-systemd;ppc64le-systemd;rv64_lp64d-systemd"
 )
 
 # Find latest manifest


### PR DESCRIPTION
23.0 profile renamed the old systemd-mergedusr profile to systemd. Image
builds has been failing for some time because of this change.

https://www.gentoo.org/support/news-items/2024-03-22-new-23-profiles.html