### PR TITLE
actions: roll forward actions versions

### DIFF
--- a/.github/actions/container_build/action.yml
+++ b/.github/actions/container_build/action.yml
@@ -11,9 +11,9 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
     - name: Set up buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Set up TARGET
       run: echo "TARGET=${{ inputs.target }}" | tee $GITHUB_ENV
       shell: bash
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: docker run --rm "${ORG}/${TARGET/-/:}" emerge --info
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       if: |
         github.ref_name == 'master' && github.repository_owner == 'gentoo' &&
         (github.event_name == 'schedule' || github.event_name == 'push')

--- a/.github/actions/manifest_build/action.yml
+++ b/.github/actions/manifest_build/action.yml
@@ -14,7 +14,7 @@ runs:
       run: echo "TARGET=${{ inputs.target }}" | tee $GITHUB_ENV
       shell: bash
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.dockerhub_username }}
         password: ${{ inputs.dockerhub_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build ${{ matrix.target }}
         uses: ./.github/actions/container_build
         with:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build ${{ matrix.target }}
         uses: ./.github/actions/manifest_build
         with:

--- a/.github/workflows/portage.yml
+++ b/.github/workflows/portage.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build ${{ matrix.target }}
         uses: ./.github/actions/container_build
         with:


### PR DESCRIPTION
Necessary to get away from old Node:

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/