### PR TITLE
Add more friendly aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,8 @@ jobs:
           - stage3:ssemath-t64
           - stage3:ssemath-t64-systemd
           - stage3:systemd
+          - stage3:t64
+          - stage3:t64-systemd
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     steps:

--- a/deploy-manifests.sh
+++ b/deploy-manifests.sh
@@ -54,6 +54,12 @@ case "${TARGET}" in
 	"stage3:systemd")
 	    TAGS=("amd64-systemd" "armv5tel-systemd" "armv6j_hardfp-systemd" "armv7a_hardfp-systemd" "arm64-systemd" "i686-systemd" "ppc64le-systemd" "rv64_lp64d-systemd")
 		;;
+	"stage3:t64")
+	    TAGS=("amd64-openrc" "arm64-openrc" "i686-ssemath-t64-openrc" "ppc64le-openrc" "rv64_lp64d-openrc" "s390x")
+		;;
+	"stage3:t64-systemd")
+	    TAGS=("amd64-systemd" "arm64-systemd" "i686-ssemath-t64-systemd" "ppc64le-systemd" "rv64_lp64d-systemd")
+		;;
 	*)
 		echo "Done! No manifests to push for TARGET=${TARGET}."
 	    exit 0

--- a/deploy-manifests.sh
+++ b/deploy-manifests.sh
@@ -40,10 +40,10 @@ case "${TARGET}" in
 	    TAGS=("amd64-musl-llvm" "arm64-musl-llvm")
 		;;
 	"stage3:nomultilib")
-	    TAGS=("amd64-nomultilib-openrc")
+	    TAGS=("amd64-nomultilib-openrc" "armv5tel-openrc" "armv6j_hardfp-openrc" "armv7a_hardfp-openrc" "arm64-openrc" "i686-openrc" "ppc64le-openrc" "rv64_lp64d-openrc" "s390x")
 		;;
 	"stage3:nomultilib-systemd")
-	    TAGS=("amd64-nomultilib-systemd")
+	    TAGS=("amd64-nomultilib-systemd" "armv5tel-systemd" "armv6j_hardfp-systemd" "armv7a_hardfp-systemd" "arm64-systemd" "i686-systemd" "ppc64le-systemd" "rv64_lp64d-systemd")
 		;;
 	"stage3:ssemath-t64")
 	    TAGS=("i686-ssemath-t64-openrc")


### PR DESCRIPTION
See commits for details. Basically, makes the following possible:

    # any non-multilib images, including architectures with no multilib at all
    FROM gentoo/stage3:nomultilib
    # any image with 64-bit time_t, including 64-bit architectures
    FROM gentoo/stage3:t64